### PR TITLE
chore: grafana internal credentials

### DIFF
--- a/.github/workflows/pull-request-develop.yml
+++ b/.github/workflows/pull-request-develop.yml
@@ -48,12 +48,13 @@ jobs:
       actions: read
     steps:
       - name: ci-lint
-        uses: smartcontractkit/.github/actions/ci-lint-go@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # ci-lint-go@0.1.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-lint-go@0.2.1
         with:
           # grafana inputs
           metrics-job-name: ci-lint
-          gc-basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           # env inputs
           use-env-files: "true"
           env-files: ./tools/env/ci.env
@@ -68,12 +69,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-lint-misc
-        uses: smartcontractkit/.github/actions/ci-lint-misc@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # ci-lint-misc@0.1.0
+        uses: smartcontractkit/.github/actions/ci-lint-misc@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-misc@0.1.1
         with:
           # grafana inputs
           metrics-job-name: ci-lint-misc
-          gc-basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
 
   ci-test:
     runs-on: ubuntu-latest
@@ -83,12 +85,13 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # ci-test-go@0.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-test-go@0.1.2
         with:
           # grafana inputs
           metrics-job-name: ci-test
-          gc-basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           # docker inputs
           use-docker-compose: "true"
           docker-compose-workdir: ./tools/docker/setup-postgres
@@ -107,13 +110,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-sonarqube
-        # TODO update to pin a specific commit once ready
-        uses: smartcontractkit/.github/actions/ci-sonarqube@re-2162/update-ci-sonarqube-lint
+        uses: smartcontractkit/.github/actions/ci-sonarqube@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-sonarqube@0.3.2
         with:
           # grafana inputs
           metrics-job-name: ci-sonarqube
-          gc-basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           # sonarqube inputs
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           sonar-host-url: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -40,12 +40,13 @@ jobs:
       actions: read
     steps:
       - name: ci-lint
-        uses: smartcontractkit/.github/actions/ci-lint-go@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # ci-lint-go@0.1.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-lint-go@0.2.1
         with:
           # grafana inputs
           metrics-job-name: ci-lint
-          gc-basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           # env inputs
           use-env-files: "true"
           env-files: ./tools/env/ci.env
@@ -64,12 +65,13 @@ jobs:
       actions: read
     steps:
       - name: ci-test
-        uses: smartcontractkit/.github/actions/ci-test-go@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # ci-test-go@0.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-test-go@0.1.2
         with:
           # grafana inputs
           metrics-job-name: ci-test
-          gc-basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           # docker inputs
           use-docker-compose: "true"
           docker-compose-workdir: ./tools/docker/setup-postgres
@@ -87,13 +89,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-sonarqube
-        # TODO update to newest release
-        uses: smartcontractkit/.github/actions/ci-sonarqube@cc4cbbd6d39a8e84915b356379a4ef6a16dceaf9 # ci-sonarqube@0.2.0
+        uses: smartcontractkit/.github/actions/ci-sonarqube@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-sonarqube@0.3.2
         with:
           # grafana inputs
           metrics-job-name: ci-sonarqube
-          gc-basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          gc-host: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           # sonarqube inputs
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           sonar-host-url: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/sigscanner.yml
+++ b/.github/workflows/sigscanner.yml
@@ -26,9 +26,10 @@ jobs:
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d1618b772a97fd87e6505de97b872ee0b1f1729a # v2.0.2
+        uses: smartcontractkit/push-gha-metrics-action@v2.2.0
         with:
-          basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          basic-auth: ${{ secrets.GRAFANA_CLOUGRAFANA_INTERNAL_BASIC_AUTHD_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           this-job-name: sigscanner-check
         continue-on-error: true


### PR DESCRIPTION
### Changes

Bumping all .github actions and now passing grafana org-id inputs 

Related: https://github.com/smartcontractkit/chainlink-feeds/pull/59

### Post-Merge
- [ ] Delete repo `GRAFANA-CLOUD-*` credentials

---

RE-2240