### PR TITLE
RE-2527 use go specific sonarqube action

### DIFF
--- a/.github/workflows/pull-request-develop.yml
+++ b/.github/workflows/pull-request-develop.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-sonarqube@0.3.2
+        uses: smartcontractkit/.github/actions/ci-sonarqube-go@3e11dbc45e4c8b18dd996fb417ccf22056176388 # ci-sonarqube-go@0.1.0
         with:
           # grafana inputs
           metrics-job-name: ci-sonarqube

--- a/.github/workflows/push-develop.yml
+++ b/.github/workflows/push-develop.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube@5b1046c28343660ecb84844c6fa95a66d1cdb52e # ci-sonarqube@0.3.2
+        uses: smartcontractkit/.github/actions/ci-sonarqube-go@3e11dbc45e4c8b18dd996fb417ccf22056176388 # ci-sonarqube-go@0.1.0
         with:
           # grafana inputs
           metrics-job-name: ci-sonarqube


### PR DESCRIPTION
We have created a new github action [ci-sonarqube-go@0.1.0](https://github.com/smartcontractkit/.github/releases/tag/ci-sonarqube-go%400.1.0) that's specifically for running sonarqube scans for Golang, updating the repo to start using that